### PR TITLE
Fix filtering of armv7l platforms in JLL wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MbedTLS_jll"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.0+1"
+version = "2.16.0+2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/MbedTLS_jll.jl
+++ b/src/MbedTLS_jll.jl
@@ -34,7 +34,7 @@ artifacts = Pkg.Artifacts.load_artifacts_toml(artifacts_toml; pkg_uuid=UUID("c8f
 platforms = [Pkg.Artifacts.unpack_platform(e, "MbedTLS", artifacts_toml) for e in artifacts["MbedTLS"]]
 
 # Filter platforms based on what wrappers we've generated on-disk
-platforms = filter(p -> isfile(joinpath(@__DIR__, "wrappers", triplet(p) * ".jl")), platforms)
+filter!(p -> isfile(joinpath(@__DIR__, "wrappers", replace(triplet(p), "arm-" => "armv7l-") * ".jl")), platforms)
 
 # From the available options, choose the best platform
 best_platform = select_platform(Dict(p => triplet(p) for p in platforms))


### PR DESCRIPTION
@Alexander-Barth could you please checkout this branch and tell me if this works for you?  https://github.com/JuliaPackaging/Yggdrasil/pull/887 will be blocked for a while because of a [bug in BinaryBuilder](https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/675), so directly patching the wrapper may be the fastest thing to do.