### PR TITLE
use arm-* wrappers on armv7l-*

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MbedTLS_jll"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.0+1"
+version = "2.16.0+2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/MbedTLS_jll.jl
+++ b/src/MbedTLS_jll.jl
@@ -34,7 +34,7 @@ artifacts = Pkg.Artifacts.load_artifacts_toml(artifacts_toml; pkg_uuid=UUID("c8f
 platforms = [Pkg.Artifacts.unpack_platform(e, "MbedTLS", artifacts_toml) for e in artifacts["MbedTLS"]]
 
 # Filter platforms based on what wrappers we've generated on-disk
-platforms = filter(p -> isfile(joinpath(@__DIR__, "wrappers", triplet(p) * ".jl")), platforms)
+filter!(p -> isfile(joinpath(@__DIR__, "wrappers", replace(triplet(p), "armv7l-" => "arm-") * ".jl")), platforms)
 
 # From the available options, choose the best platform
 best_platform = select_platform(Dict(p => triplet(p) for p in platforms))
@@ -44,7 +44,7 @@ if best_platform === nothing
     @debug("Unable to load MbedTLS; unsupported platform $(triplet(platform_key_abi()))")
 else
     # Load the appropriate wrapper
-    include(joinpath(@__DIR__, "wrappers", "$(best_platform).jl"))
+    include(joinpath(@__DIR__, "wrappers", "$(replace(best_platform,"armv7l-" => "arm-")).jl"))
 end
 
 end  # module MbedTLS_jll


### PR DESCRIPTION
This is an alternative pull request for addressing the issue described here:
https://discourse.julialang.org/t/libmbedtls-not-defined-in-julia-1-4-1-on-arm-raspberry-pi/37778/5

